### PR TITLE
Making graham-campbell/manager compatible with Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
             "illuminate/support": "5.0.*|5.1.*|5.2.*||5.3.*|5.4.*|5.5.*|5.6.*",
             "mautic/api-library":"2.1.1",
             "guzzlehttp/guzzle": "^6.2",
-            "graham-campbell/manager": "^3.0"
+            "graham-campbell/manager": "^4.0"
         },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I forgot this on the last pull request. Now everything is fine